### PR TITLE
Take care about the non-served RegistryProxy CR even after second CR was removed

### DIFF
--- a/components/operator/state/served_filter.go
+++ b/components/operator/state/served_filter.go
@@ -13,17 +13,13 @@ import (
 
 // sFnServedFilter checks if only one instance of RegistryProxy is running and disallows additional instances
 func sFnServedFilter(ctx context.Context, m *fsm.StateMachine) (fsm.StateFn, *ctrl.Result, error) {
-	if m.State.RegistryProxy.IsServedEmpty() {
+	if m.State.RegistryProxy.IsServedEmpty() || m.State.RegistryProxy.Status.Served == v1alpha1.ServedFalse {
 		err := setServedStatus(ctx, m)
 		if err != nil {
 			return stopWithEventualError(err)
 		}
 	}
 
-	// instance is marked, we can now decide what to do with it
-	if m.State.RegistryProxy.Status.Served == v1alpha1.ServedFalse {
-		return stop()
-	}
 	return nextState(sFnAddFinalizer)
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- requeue all RegistryProxy CRs after one of them is removed (to recalculated the `.status.served` field)
- recalculate the `.status.served` field on every reconciliation to give all resources a "second chance" 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/1963