### PR TITLE
Add a gate that checks the type of contributor before running builds

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -4,7 +4,6 @@ on:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
-  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:
@@ -14,8 +13,19 @@ jobs:
   gitleaks:
     uses: ./.github/workflows/_gitleaks.yaml
 
+  select-environment:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+    steps:
+      - name: Approved
+        run: echo "Build approved, environment selected"
+
   builds:
+    needs: select-environment
     uses: ./.github/workflows/_build.yaml
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     with:
       purpose: "dev"
       img_directory: "dev"

--- a/components/registry-proxy/cmd/main.go
+++ b/components/registry-proxy/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kyma-project/manager-toolkit/logging/logger"
 	securityclientv1 "istio.io/client-go/pkg/apis/security/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"

--- a/components/registry-proxy/cmd/main.go
+++ b/components/registry-proxy/cmd/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kyma-project/manager-toolkit/logging/logger"
 	securityclientv1 "istio.io/client-go/pkg/apis/security/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Environment in context of this PR mean the environments configured in settings of this repository
External contributors require team member approval so if someone is not part of @kyma-project/otters and neither is owner of this repository he will fall under restricted environment and require our manual approval to proceed with builds, if a team member makes a contribution the build will run automatically cause it will fall into the "internal" environment

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
